### PR TITLE
fix: compression for AppImage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,13 +133,18 @@ jobs:
           node-version: "20"
           cache: "npm"
       - uses: dtolnay/rust-toolchain@stable
-      - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf squashfs-tools
       - run: npm ci
       # CI has no FUSE; linuxdeploy is an AppImage and needs extract-and-run.
       - run: npm run tauri build -- --bundles appimage --ci
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
-          LDAI_COMP: gzip
+      - name: Repack AppImage with gzip for AppImageLauncher
+        run: |
+          for f in src-tauri/target/release/bundle/appimage/*.AppImage; do
+            chmod +x scripts/repack-appimage-gzip.sh
+            ./scripts/repack-appimage-gzip.sh "$f"
+          done
       - uses: actions/upload-artifact@v4
         with:
           name: linux-appimage-installer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
       - run: npm run tauri build -- --bundles appimage --ci
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
+          LDAI_COMP: gzip
       - uses: actions/upload-artifact@v4
         with:
           name: linux-appimage-installer

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,10 +1,12 @@
 # Build installers and attach them to the GitHub Release created by Release Please.
-# Runs when a release is published (after the release PR is merged).
-name: Release assets
+# Triggers on tag push (e.g. v1.0.0) because release:published does not fire when
+# the release is created by another workflow using GITHUB_TOKEN.
+name: Release Assets
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -16,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -41,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -69,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.ref_name }}
 
       - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
@@ -102,7 +104,7 @@ jobs:
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ github.ref_name }}
           files: |
             artifacts/windows-msi/*.msi
             artifacts/macos-app/*.zip

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf squashfs-tools
 
       - uses: actions/setup-node@v4
         with:
@@ -86,8 +86,13 @@ jobs:
       - run: npm run tauri build -- --bundles appimage --ci
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
-          # Use gzip so AppImageLauncher (libsquashfs with only xz/zlib) can read the image
-          LDAI_COMP: gzip
+
+      - name: Repack AppImage with gzip for AppImageLauncher
+        run: |
+          for f in src-tauri/target/release/bundle/appimage/*.AppImage; do
+            chmod +x scripts/repack-appimage-gzip.sh
+            ./scripts/repack-appimage-gzip.sh "$f"
+          done
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -86,6 +86,8 @@ jobs:
       - run: npm run tauri build -- --bundles appimage --ci
         env:
           APPIMAGE_EXTRACT_AND_RUN: 1
+          # Use gzip so AppImageLauncher (libsquashfs with only xz/zlib) can read the image
+          LDAI_COMP: gzip
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Optional: use the **Tauri Development** launch config in VS Code (Run and Debug)
 
 - **Windows (MSI)**: On Windows with WiX installed, `npm run tauri build` produces an MSI in `src-tauri/target/release/bundle/msi/`.
 - **macOS (.app)**: On macOS, `npm run tauri build` produces the app bundle (e.g. in `src-tauri/target/release/bundle/macos/`).
-- **Linux**: `npm run tauri build` produces .deb and AppImage. In environments without FUSE (e.g. Docker, CI), set `APPIMAGE_EXTRACT_AND_RUN=1` so the linuxdeploy AppImage can run.
+- **Linux**: `npm run tauri build` produces .deb and AppImage. In environments without FUSE (e.g. Docker, CI), set `APPIMAGE_EXTRACT_AND_RUN=1` so the linuxdeploy AppImage can run. The CI/release build uses `LDAI_COMP=gzip` so AppImageLauncher (and older libsquashfs) can read the image. If you see “Squashfs image uses (null) compression” when launching via AppImageLauncher, run the AppImage directly: `./announcemint.AppImage` (or rebuild with `LDAI_COMP=gzip`).
 
 ## Rebranding
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Optional: use the **Tauri Development** launch config in VS Code (Run and Debug)
 
 - **Windows (MSI)**: On Windows with WiX installed, `npm run tauri build` produces an MSI in `src-tauri/target/release/bundle/msi/`.
 - **macOS (.app)**: On macOS, `npm run tauri build` produces the app bundle (e.g. in `src-tauri/target/release/bundle/macos/`).
-- **Linux**: `npm run tauri build` produces .deb and AppImage. In environments without FUSE (e.g. Docker, CI), set `APPIMAGE_EXTRACT_AND_RUN=1` so the linuxdeploy AppImage can run. The CI/release build uses `LDAI_COMP=gzip` so AppImageLauncher (and older libsquashfs) can read the image. If you see “Squashfs image uses (null) compression” when launching via AppImageLauncher, run the AppImage directly: `./announcemint.AppImage` (or rebuild with `LDAI_COMP=gzip`).
+- **Linux**: `npm run tauri build` produces .deb and AppImage. In environments without FUSE (e.g. Docker, CI), set `APPIMAGE_EXTRACT_AND_RUN=1` so the linuxdeploy AppImage can run. If you see “Squashfs image uses (null) compression” when launching via AppImageLauncher, run `./scripts/repack-appimage-gzip.sh path/to/foo.AppImage` or run the AppImage directly. Release builds are repacked with gzip so AppImageLauncher can read them.
 
 ## Rebranding
 

--- a/scripts/repack-appimage-gzip.sh
+++ b/scripts/repack-appimage-gzip.sh
@@ -2,7 +2,8 @@
 # Repack an AppImage so its squashfs uses gzip compression.
 # This allows AppImageLauncher (and older libsquashfs that only support xz/zlib) to read the image.
 # Usage: repack-appimage-gzip.sh <path-to.AppImage>
-# Requires: squashfs-tools (mksquashfs, unsquashfs)
+# Requires: squashfs-tools (mksquashfs)
+# Uses the AppImage runtime's --appimage-extract for reliable extraction across formats and compression.
 
 set -euo pipefail
 
@@ -16,30 +17,41 @@ if [ ! -f "$APPIMAGE" ]; then
   echo "Not a file: $APPIMAGE" >&2
   exit 1
 fi
+APPIMAGE=$(cd "$(dirname "$APPIMAGE")" && pwd)/$(basename "$APPIMAGE")
 
-# Type 2 AppImage: payload offset at byte 8, 8 bytes little-endian
-OFFSET=$(od -An -t u8 -j 8 -N 8 -v "$APPIMAGE" | tr -d ' ')
-if [ -z "$OFFSET" ] || [ "$OFFSET" -le 0 ]; then
-  echo "Could not read payload offset from $APPIMAGE (not Type 2?)" >&2
-  exit 1
-fi
+# Ensure executable for --appimage-extract / --appimage-offset
+chmod +x "$APPIMAGE"
 
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
 
-# Split runtime and payload
-head -c "$OFFSET" "$APPIMAGE" > "$WORKDIR/runtime"
-tail -c +$((OFFSET + 1)) "$APPIMAGE" > "$WORKDIR/payload.sqfs"
+# Copy AppImage to workdir so --appimage-extract works in a clean dir
+cp "$APPIMAGE" "$WORKDIR/input.AppImage"
+chmod +x "$WORKDIR/input.AppImage"
+cd "$WORKDIR"
 
-# Extract payload (supports zstd from current build)
-unsquashfs -f -d "$WORKDIR/appdir" "$WORKDIR/payload.sqfs"
+# Use AppImage runtime's built-in extraction (handles format variations, zstd, etc.)
+if ! ./input.AppImage --appimage-extract >/dev/null 2>&1; then
+  echo "AppImage does not support --appimage-extract (not Type 2?)" >&2
+  exit 1
+fi
 
-# Repack with gzip for AppImageLauncher compatibility
-mksquashfs "$WORKDIR/appdir" "$WORKDIR/new.sqfs" -comp gzip -noappend
+# Get payload offset from runtime for reconstructing the file
+OFFSET=$(./input.AppImage --appimage-offset 2>/dev/null || true)
+if [ -z "$OFFSET" ] || [ "$OFFSET" -le 0 ]; then
+  echo "Could not get payload offset from AppImage" >&2
+  exit 1
+fi
 
-# Replace original with runtime + gzip squashfs
-cat "$WORKDIR/runtime" "$WORKDIR/new.sqfs" > "$WORKDIR/new.AppImage"
-chmod +x "$WORKDIR/new.AppImage"
-mv "$WORKDIR/new.AppImage" "$APPIMAGE"
+# Extract runtime (bytes before payload)
+head -c "$OFFSET" input.AppImage > runtime
+
+# Repack extracted squashfs-root with gzip for AppImageLauncher compatibility
+mksquashfs squashfs-root new.sqfs -comp gzip -noappend
+
+# Reconstruct AppImage
+cat runtime new.sqfs > new.AppImage
+chmod +x new.AppImage
+mv new.AppImage "$APPIMAGE"
 
 echo "Repacked $APPIMAGE with gzip compression"

--- a/scripts/repack-appimage-gzip.sh
+++ b/scripts/repack-appimage-gzip.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Repack an AppImage so its squashfs uses gzip compression.
+# This allows AppImageLauncher (and older libsquashfs that only support xz/zlib) to read the image.
+# Usage: repack-appimage-gzip.sh <path-to.AppImage>
+# Requires: squashfs-tools (mksquashfs, unsquashfs)
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <path-to.AppImage>" >&2
+  exit 1
+fi
+
+APPIMAGE="$1"
+if [ ! -f "$APPIMAGE" ]; then
+  echo "Not a file: $APPIMAGE" >&2
+  exit 1
+fi
+
+# Type 2 AppImage: payload offset at byte 8, 8 bytes little-endian
+OFFSET=$(od -An -t u8 -j 8 -N 8 -v "$APPIMAGE" | tr -d ' ')
+if [ -z "$OFFSET" ] || [ "$OFFSET" -le 0 ]; then
+  echo "Could not read payload offset from $APPIMAGE (not Type 2?)" >&2
+  exit 1
+fi
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Split runtime and payload
+head -c "$OFFSET" "$APPIMAGE" > "$WORKDIR/runtime"
+tail -c +$((OFFSET + 1)) "$APPIMAGE" > "$WORKDIR/payload.sqfs"
+
+# Extract payload (supports zstd from current build)
+unsquashfs -f -d "$WORKDIR/appdir" "$WORKDIR/payload.sqfs"
+
+# Repack with gzip for AppImageLauncher compatibility
+mksquashfs "$WORKDIR/appdir" "$WORKDIR/new.sqfs" -comp gzip -noappend
+
+# Replace original with runtime + gzip squashfs
+cat "$WORKDIR/runtime" "$WORKDIR/new.sqfs" > "$WORKDIR/new.AppImage"
+chmod +x "$WORKDIR/new.AppImage"
+mv "$WORKDIR/new.AppImage" "$APPIMAGE"
+
+echo "Repacked $APPIMAGE with gzip compression"


### PR DESCRIPTION
Fix a compression configuration error that prevented the AppImage bundle from running via AppImageLauncher.

```
➜  ~ ~/Applications/announcemint.appimage 
/usr/bin/AppImageLauncher: /lib64/libcurl.so.4: no version information available (required by /usr/bin/../lib/x86_64-linux-gnu/appimagelauncher/libappimageupdate.so)
QSocketNotifier: Can only be used with threads started with QThread
Squashfs image uses (null) compression, this version supports only xz, zlib.
ERROR: appimage_shall_not_be_integrated : sqfs_open_image error: /home/nick/Applications/announcemint.appimage
AppImageLauncher error: appimage_shall_not_be_integrated() failed (returned -1)
Squashfs image uses (null) compression, this version supports only xz, zlib.
ERROR: appimage_is_terminal_app : sqfs_open_image error: /home/nick/Applications/announcemint.appimage
AppImageLauncher error: appimage_is_terminal_app() failed (returned -1)
```