### PR TITLE
feat: improve voice options ux

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "announcemint"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "ashpd",
  "aws-config",

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,6 +69,7 @@ const openDrawer = ref<"aws" | "voice" | "destination" | "dangerzone" | null>(
   null,
 );
 const openAwsSubdrawer = ref<"account" | "proxy" | null>(null);
+const loadingVoices = ref(false);
 const rememberPrompts = ref(true);
 const promptFileNameFormat = ref("hyphen");
 
@@ -171,6 +172,8 @@ async function checkSession() {
 }
 
 async function loadVoices() {
+  if (sessionOk.value !== true) return;
+  loadingVoices.value = true;
   try {
     voices.value = await invoke("polly_describe_voices", {
       languageCode: effectiveLanguageCode.value || null,
@@ -185,6 +188,8 @@ async function loadVoices() {
     }
   } catch (e) {
     console.error(e);
+  } finally {
+    loadingVoices.value = false;
   }
 }
 
@@ -234,6 +239,9 @@ async function checkCredentialsAndPermissions() {
       "check_credentials_and_permissions",
     );
     credentialsAndPermissionsResult.value = result;
+    if (result.authenticated) {
+      await checkSession();
+    }
   } catch (e) {
     credentialsAndPermissionsResult.value = {
       authenticated: false,
@@ -523,6 +531,13 @@ watch(
   },
 );
 
+// When AWS session becomes valid, refresh voices so the Voice dropdown is populated.
+watch(sessionOk, (newVal, oldVal) => {
+  if (newVal === true && oldVal === false) {
+    loadVoices();
+  }
+});
+
 /** Sync window theme after mount so app content follows dark/light. Runs in Vue lifecycle so it cannot block initial render. On Linux uses get_system_theme (XDG portal). */
 function minimizeWindow(): void {
   getCurrentWindow().minimize();
@@ -605,9 +620,9 @@ onMounted(async () => {
     console.error(e);
   }
   loadPresets();
-  loadConfig().then(() => {
+  loadConfig().then(async () => {
+    await checkSession();
     loadVoices();
-    checkSession();
     checkCredentialsAndPermissions();
   });
 });
@@ -1129,15 +1144,31 @@ onMounted(async () => {
           </div>
         </section>
 
-        <!-- Drawer 2: Voice Options -->
+        <!-- Drawer 2: Voice Options (requires valid AWS session for polly:DescribeVoices) -->
         <section class="drawer accordion-drawer">
           <button
             type="button"
             class="drawer-header"
+            :class="{ 'drawer-header-disabled': sessionOk !== true }"
+            :disabled="sessionOk !== true"
             :aria-expanded="openDrawer === 'voice'"
+            :title="
+              sessionOk !== true
+                ? 'Sign in to AWS to access voice options'
+                : undefined
+            "
             @click="openDrawer = openDrawer === 'voice' ? null : 'voice'"
           >
-            <h2 class="drawer-title">Voice Options</h2>
+            <h2 class="drawer-title">
+              Voice Options
+              <span
+                v-if="sessionOk !== true"
+                class="drawer-title-hint"
+                aria-hidden="true"
+              >
+                (requires AWS session)
+              </span>
+            </h2>
             <span
               class="drawer-chevron"
               :class="{ open: openDrawer === 'voice' }"
@@ -1173,6 +1204,16 @@ onMounted(async () => {
                     {{ v.name }} ({{ v.language_code }})
                   </option>
                 </select>
+              </div>
+              <div class="form-row">
+                <button
+                  type="button"
+                  class="btn-secondary"
+                  :disabled="loadingVoices || sessionOk !== true"
+                  @click="loadVoices"
+                >
+                  {{ loadingVoices ? "Refreshing…" : "Refresh voices" }}
+                </button>
               </div>
               <div class="form-row">
                 <label>Output preset</label>
@@ -1401,12 +1442,21 @@ onMounted(async () => {
   color: inherit;
   text-align: left;
 }
-.drawer-header:hover {
+.drawer-header:hover:not(:disabled) {
   background: var(--color-bg);
+}
+.drawer-header:disabled,
+.drawer-header-disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
 }
 .drawer-header .drawer-title {
   margin: 0;
   flex: 1;
+}
+.drawer-title-hint {
+  font-weight: normal;
+  opacity: 0.85;
 }
 .drawer-chevron {
   font-size: 0.75rem;


### PR DESCRIPTION
## Improve Voice Options UX when AWS session is invalid

### Problem
When the app runs without a valid AWS session and language is set to System Locale (default), the Voice dropdown in Settings is empty because `polly:DescribeVoices` cannot be called. Users had no clear indication that voice options depend on a valid AWS session, and no way to refresh the list after signing in.

### Solution
- **Disable Voice Options when there's no session.** The Voice Options drawer is disabled when there is no valid AWS session. The header shows "(requires AWS session)" and a tooltip ("Sign in to AWS to access voice options") so it's clear that AWS is required for voice selection.
- **Refresh voices when a session is established.** When the session becomes valid (e.g. after configuring credentials and using "Check credentials"), the app re-runs session checks and automatically refreshes the list of engines/voices so the Voice dropdown is populated without leaving the screen.
- **Refresh Voices control.** A "Refresh voices" button was added inside the Voice Options drawer so users can manually reload the list (e.g. after changing region or profile). It shows a "Refreshing…" state while the request is in progress.

### Changes
- **Settings drawer (Voice Options):** Drawer header is disabled when `sessionOk !== true`; disabled state is styled (opacity, cursor). Subtitle "(requires AWS session)" and tooltip when disabled. New "Refresh voices" button below the Voice select; disabled when there's no session or while a refresh is running.
- **Session and voice loading:** `loadVoices()` returns early if there's no valid session and uses a `loadingVoices` flag for the Refresh button state. Watcher on `sessionOk`: when it changes from `false` to `true`, `loadVoices()` is called so the list updates after sign-in. After a successful "Check credentials" in AWS settings, `checkSession()` is called so `sessionOk` (and thus the traffic light and voice list) stay in sync. On app load, `checkSession()` is awaited before `loadVoices()` so a valid session at startup populates voices immediately.
- **Styling:** `.drawer-header-disabled` and `:disabled` styles for the Voice Options header; `.drawer-title-hint` for the "(requires AWS session)" text; hover background on drawer headers only when not disabled.