### PR TITLE
fix: generate prompts button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -179,12 +179,11 @@ async function loadVoices() {
       languageCode: effectiveLanguageCode.value || null,
       engine: engine.value || null,
     });
-    if (
-      voiceId.value &&
-      voices.value.length &&
-      !voices.value.some((v) => v.id === voiceId.value)
-    ) {
-      voiceId.value = voices.value[0].id;
+    if (voices.value.length) {
+      const currentInList = voiceId.value && voices.value.some((v) => v.id === voiceId.value);
+      if (!currentInList) {
+        voiceId.value = voices.value[0].id;
+      }
     }
   } catch (e) {
     console.error(e);
@@ -755,7 +754,7 @@ onMounted(async () => {
           <button
             type="button"
             class="btn-primary"
-            :disabled="generating || !outputDir || totalLines === 0 || !voiceId"
+            :disabled="generating || sessionOk !== true || !outputDir || totalLines === 0 || !voiceId"
             @click="generate"
           >
             {{ generating ? "Generating…" : "Generate Prompts" }}


### PR DESCRIPTION
## Fix Generate Prompts button staying disabled after creating valid AWS session

### Problem

* **Generate Prompts stays greyed out after signing in:** When starting the app without a valid AWS session, the Generate Prompts button is disabled. After the user adds credentials in Settings and gets a valid session (e.g. via "Check credentials and permissions"), the button remained greyed out. The button depends on `voiceId` being set; with no initial session, voices were never loaded and the voice dropdown stayed empty. When the session later became valid, `loadVoices()` ran and populated the dropdown but did not set a default voice when `voiceId` was empty, so `!voiceId` kept the button disabled.
* **Session state not reflected on the button:** The button’s disabled state did not include session validity, so the UI did not clearly show that a valid session is required to generate.

### Solution

* **Default voice when voices load:** In `loadVoices()`, when the voices list is loaded and the current `voiceId` is empty or not in the new list, set `voiceId` to the first available voice. After a valid session is created and voices load, a voice is selected so the button can enable when the other conditions (output dir, prompts) are met.
* **Button disabled when session is invalid:** Add `sessionOk !== true` to the Generate Prompts button’s `:disabled` expression so the button is explicitly disabled without a valid session and automatically enables when the session becomes valid.

### Changes

* **`src/App.vue`:** In `loadVoices()`, replace the condition that only updated `voiceId` when it was truthy but not in the list with logic that sets `voiceId` to `voices[0].id` whenever the current value is empty or not in the loaded list. In the main view, add `sessionOk !== true` to the Generate Prompts button’s disabled condition.