### PR TITLE
feat: add descriptive hint

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-windows:
-    name: Build Windows MSI
+    name: Build Windows MSI and EXE
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
           workspaces: "src-tauri"
 
       - run: npm ci
-      - run: npm run tauri build -- --bundles msi --ci --no-sign
+      - run: npm run tauri build -- --bundles msi,nsis --ci --no-sign
         env:
           TAURI_SIGNING_PRIVATE_KEY: ""
 
@@ -39,6 +39,11 @@ jobs:
         with:
           name: windows-msi
           path: src-tauri/target/release/bundle/msi/*.msi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-nsis
+          path: src-tauri/target/release/bundle/nsis/*.exe
 
   build-macos:
     name: Build macOS app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -89,7 +86,7 @@ jobs:
             chore
 
   build-installers:
-    name: Build installers (Windows MSI, macOS app, Linux AppImage)
+    name: Build installers
     uses: ./.github/workflows/build-installers.yml
     with:
       ref: ${{ github.sha }}

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -6,7 +6,8 @@ name: Release Assets
 
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 permissions:
   contents: write
@@ -39,6 +40,7 @@ jobs:
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
             artifacts/windows-msi/*.msi \
+            artifacts/windows-nsis/*.exe \
             artifacts/macos-app/*.zip \
             artifacts/linux-appimage/*.AppImage \
             --clobber

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ App name, publisher, docs URL, and GitHub repo are set in **`brand.json`** at th
 
 ### Getting the app
 
-Prebuilt installers (Windows MSI, macOS .app, Linux AppImage) are published on the [Releases](https://github.com/hlvtechnologies/announcemint/releases) page. You need [AWS credentials](#requirements) with Polly permissions before generating speech.
+Prebuilt installers (Windows MSI and NSIS .exe, macOS .app, Linux AppImage) are published on the [Releases](https://github.com/hlvtechnologies/announcemint/releases) page. On Windows, the **NSIS** installer (`.exe`) lets you choose **per-user** or **system-wide** install; the MSI installs per-machine. You need [AWS credentials](#requirements) with Polly permissions before generating speech.
 
 ## Features
 
@@ -133,7 +133,7 @@ Optional: use the **Tauri Development** launch config in VS Code (Run and Debug)
 
 ## Build
 
-- **Windows (MSI)**: On Windows with WiX installed, `npm run tauri build` produces an MSI in `src-tauri/target/release/bundle/msi/`.
+- **Windows**: On Windows with WiX and NSIS installed, `npm run tauri build -- --bundles msi,nsis` produces an MSI in `src-tauri/target/release/bundle/msi/` and an NSIS `.exe` in `src-tauri/target/release/bundle/nsis/`. The NSIS installer prompts for **per-user** or **per-machine** install (see `bundle.windows.nsis.installMode: "both"` in `tauri.conf.json`).
 - **macOS (.app)**: On macOS, `npm run tauri build` produces the app bundle (e.g. in `src-tauri/target/release/bundle/macos/`).
 - **Linux**: `npm run tauri build` produces .deb and AppImage. In environments without FUSE (e.g. Docker, CI), set `APPIMAGE_EXTRACT_AND_RUN=1` so the linuxdeploy AppImage can run. If you see “Squashfs image uses (null) compression” when launching via AppImageLauncher, run `./scripts/repack-appimage-gzip.sh path/to/foo.AppImage` or run the AppImage directly. Release builds are repacked with gzip so AppImageLauncher can read them. If you get "Could not create default EGL display: EGL_BAD_PARAMETER" and a blank window (e.g. on Fedora with some GPUs): run with `WEBKIT_SKIA_ENABLE_CPU_RENDERING=1 ./Announcemint_*.AppImage` to force CPU rendering. Release builds use a repack step that injects this into the AppImage’s AppRun (script or binary), so newer builds should avoid the crash; to try GPU again use `WEBKIT_SKIA_ENABLE_CPU_RENDERING=0` before launching.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "announcemint"
-version = "1.0.7"
+version = "1.1.2"
 dependencies = [
  "ashpd",
  "aws-config",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,10 @@
         "type": "downloadBootstrapper",
         "silent": true
       },
-      "allowDowngrades": false
+      "allowDowngrades": false,
+      "nsis": {
+        "installMode": "both"
+      }
     },
     "android": {
       "minSdkVersion": 24,

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,13 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open, confirm } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { APP_NAME, GITHUB_REPO, HELP_DOCS_URL, SHOW_HELP, SHOW_ABOUT } from "./app-config";
+import {
+  APP_NAME,
+  GITHUB_REPO,
+  HELP_DOCS_URL,
+  SHOW_HELP,
+  SHOW_ABOUT,
+} from "./app-config";
 
 const outputDir = ref<string | null>(null);
 const presetName = ref("OGG Vorbis");
@@ -193,7 +199,8 @@ async function loadVoices() {
       engine: engine.value || null,
     });
     if (voices.value.length) {
-      const currentInList = voiceId.value && voices.value.some((v) => v.id === voiceId.value);
+      const currentInList =
+        voiceId.value && voices.value.some((v) => v.id === voiceId.value);
       if (!currentInList) {
         voiceId.value = voices.value[0].id;
       }
@@ -774,12 +781,21 @@ onMounted(async () => {
           <button
             type="button"
             class="btn-primary"
-            :disabled="generating || sessionOk !== true || !outputDir || totalLines === 0 || !voiceId"
+            :disabled="
+              generating ||
+              sessionOk !== true ||
+              !outputDir ||
+              totalLines === 0 ||
+              !voiceId
+            "
             @click="generate"
           >
             {{ generating ? "Generating…" : "Generate Prompts" }}
           </button>
-          <p v-if="!generating && generateButtonBlockers.length" class="generate-hint">
+          <p
+            v-if="!generating && generateButtonBlockers.length"
+            class="generate-hint"
+          >
             To enable: {{ generateButtonBlockers.join("; ") }}.
           </p>
         </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open, confirm } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { APP_NAME, GITHUB_REPO, HELP_DOCS_URL } from "./app-config";
+import { APP_NAME, GITHUB_REPO, HELP_DOCS_URL, SHOW_HELP, SHOW_ABOUT } from "./app-config";
 
 const outputDir = ref<string | null>(null);
 const presetName = ref("OGG Vorbis");
@@ -115,6 +115,19 @@ const linesList = computed(() =>
     .filter(Boolean),
 );
 const totalLines = computed(() => linesList.value.length);
+
+/** Reasons the Generate button is disabled; shown as a hint when not generating. */
+const generateButtonBlockers = computed(() => {
+  const blockers: string[] = [];
+  if (sessionOk.value !== true)
+    blockers.push("Sign in to AWS (Settings → Connecting to AWS)");
+  if (!outputDir.value)
+    blockers.push("Select an output directory (Settings → Saving Prompts)");
+  if (totalLines.value === 0) blockers.push("Enter at least one prompt");
+  if (!voiceId.value)
+    blockers.push("Select a voice (Settings → Voice Options)");
+  return blockers;
+});
 
 function getSystemLanguageCode(): string {
   const locale =
@@ -537,6 +550,12 @@ watch(sessionOk, (newVal, oldVal) => {
   }
 });
 
+/** When returning from Settings to main, re-check session so newly configured credentials are detected and the Generate button can enable. */
+async function returnToMain(): Promise<void> {
+  await checkSession();
+  currentView.value = "main";
+}
+
 /** Sync window theme after mount so app content follows dark/light. Runs in Vue lifecycle so it cannot block initial render. On Linux uses get_system_theme (XDG portal). */
 function minimizeWindow(): void {
   getCurrentWindow().minimize();
@@ -724,6 +743,7 @@ onMounted(async () => {
             }}
           </span>
           <button
+            v-if="SHOW_HELP"
             type="button"
             class="btn-secondary"
             @click="openUrl(HELP_DOCS_URL).catch(console.error)"
@@ -759,6 +779,9 @@ onMounted(async () => {
           >
             {{ generating ? "Generating…" : "Generate Prompts" }}
           </button>
+          <p v-if="!generating && generateButtonBlockers.length" class="generate-hint">
+            To enable: {{ generateButtonBlockers.join("; ") }}.
+          </p>
         </div>
         <div v-if="progress" class="progress-panel">
           <p v-if="progressPromptName" class="progress-prompt-name">
@@ -784,7 +807,7 @@ onMounted(async () => {
         <p v-if="error" class="error">{{ error }}</p>
       </main>
 
-      <footer class="footer">
+      <footer v-if="SHOW_ABOUT" class="footer">
         <button type="button" class="footer-link" @click="showAbout = true">
           About
         </button>
@@ -795,7 +818,7 @@ onMounted(async () => {
     <template v-if="currentView === 'settings'">
       <header class="header settings-header">
         <h1 class="settings-title">Settings</h1>
-        <button type="button" class="btn-primary" @click="currentView = 'main'">
+        <button type="button" class="btn-primary" @click="returnToMain">
           Return
         </button>
       </header>
@@ -1320,8 +1343,9 @@ onMounted(async () => {
       </div>
     </template>
 
-    <!-- About modal (global) -->
+    <!-- About modal (global); only rendered when About feature is enabled -->
     <div
+      v-if="SHOW_ABOUT"
       v-show="showAbout"
       class="about-overlay"
       role="dialog"
@@ -1702,6 +1726,11 @@ onMounted(async () => {
 .error {
   color: var(--color-error);
   font-size: 0.875rem;
+}
+.generate-hint {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
 }
 .session-hint {
   margin-top: 0.75rem;

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -7,3 +7,8 @@ export const PUBLISHER = brand.publisher as string;
 export const APP_NAME = brand.appName as string;
 export const HELP_DOCS_URL = brand.docsUrl as string;
 export const GITHUB_REPO = brand.githubRepo as string;
+
+/** When true, show the Help button in the header. Default false to hide for now. */
+export const SHOW_HELP = false;
+/** When true, show the About button in the footer and the About modal. Default false to hide for now. */
+export const SHOW_ABOUT = false;


### PR DESCRIPTION
## Add main-screen hint when Generate is disabled, return-to-main session check, Help/About flags, and Windows per-user install option

### Problem

* **Unclear why Generate is disabled:** When the Generate Prompts button was disabled (e.g. after a config reset or before choosing an output directory), the UI gave no indication of what was missing. Users could have a valid AWS session, a selected voice, and prompts entered but still see a greyed-out button—often because the output directory is only set in Settings → Saving Prompts.
* **Session not re-checked when leaving Settings:** If the user configured AWS in Settings and clicked Return without using "Check credentials and permissions," the app did not re-run the session check, so the main view could still show the button as disabled even when credentials were valid.
* **No install-scope choice on Windows:** The Windows release only shipped an MSI installer (per-machine). Users could not choose a per-user install without custom WiX work.

### Solution

* **Hint under Generate button:** Add a computed list of missing requirements (AWS sign-in, output directory, prompts, voice) and show a "To enable: …" message under the button whenever it is disabled and not generating, so users know to e.g. select an output directory in Settings → Saving Prompts.
* **Re-check session on Return:** When the user leaves Settings via Return, call `checkSession()` before switching to the main view so newly saved credentials are detected and the button state updates.
* **Help and About feature flags:** Replace the single combined flag with `SHOW_HELP` and `SHOW_ABOUT` in app-config (both default `false`), and gate the Help button, footer About link, and About modal on these flags so they can be toggled independently.
* **Windows: NSIS installer with install-scope choice:** Add an NSIS installer (`.exe`) with `installMode: "both"` so users can choose per-user or system-wide at install time. Build both MSI and NSIS on Windows in CI, upload both artifacts, and attach both to GitHub Releases. Keep the MSI for per-machine and enterprise use.

### Changes

* **`src/App.vue`:** Add `generateButtonBlockers` computed and a "To enable: …" hint below the Generate button when it is disabled and not generating. Add `returnToMain()` to run `checkSession()` then switch to main, and use it for the Settings Return button. Use `SHOW_HELP` and `SHOW_ABOUT` from app-config for the Help button, footer, and About modal. Add `.generate-hint` style for the hint text. In `loadVoices()`, set default voice when the current selection is empty or not in the loaded list (so the button can enable after session becomes valid).
* **`src/app-config.ts`:** Add `SHOW_HELP` and `SHOW_ABOUT` (both `false`).
* **`src-tauri/tauri.conf.json`:** Under `bundle.windows`, add `nsis` with `installMode: "both"`.
* **`.github/workflows/build-installers.yml`:** In the Windows job, use `--bundles msi,nsis` and add an upload step for the `windows-nsis` artifact (`bundle/nsis/*.exe`).
* **`.github/workflows/release-assets.yml`:** Include `artifacts/windows-nsis/*.exe` in the release upload.
* **`.github/workflows/ci.yml`:** Remove `push: branches: [main]` so CI runs only on pull requests to `main`.
* **`README.md`:** In "Getting the app," mention Windows MSI and NSIS and that the NSIS `.exe` offers per-user or system-wide install. In the Build section, document building with `--bundles msi,nsis` and the NSIS install-mode behavior.